### PR TITLE
Fix for tools do not exit after alert

### DIFF
--- a/glyphwitch/client/main.js
+++ b/glyphwitch/client/main.js
@@ -1149,116 +1149,115 @@ Template.viewPage.events({
     $('#viewTool').removeClass('btn-light').addClass('btn-dark');
     instance.currentTool.set('view');
   },
+
   'click #selectItem'(event, instance) {
-    event.preventDefault();
-    instance.currentTool.set('select');
-    resetToolbox();
-    //set the currentTool to btn-dark
-    $('#selectItem').removeClass('btn-light').addClass('btn-dark');
-    selectedLine = instance.currentLine.get();
-    selectedWord = instance.currentWord.get();
-    currentView = instance.currentView.get();
-    console.log("selectedLine is " + selectedLine);
-    if (currentView == 'simple') {
-      image = initCropper("page");
-      const context = image.getContext('2d');
-      const page = instance.currentPage.get();
-      const documentId = instance.currentDocument.get();
-      const lines = Documents.findOne({_id: documentId}).pages[page].lines;
-      //if there are no lines, simulate clicking the exitTool button
-      if (lines.length == 0) {
-        alert("No lines to display. Use the Create Line tool to create a line.");
-        return;
-      }
-      //sort the lines by y1
-      lines.sort(function(a, b) {
-        return a.y1 - b.y1;
-      }
-      );
-      //split the canvas into multiple canvases by line
-      lines.forEach(function(line) {
-        index = lines.indexOf(line);
-        drawButton(image, 0, line.y1, image.width, line.height, 'line', index, index);
-      }
-      );
-      //hide the original image with display none
-      setCurrentHelp('To select a line, click on the line.  To cancel, click the close tool button.');
+  event.preventDefault();
+  instance.currentTool.set('select');
+  resetToolbox();
+  //set the currentTool to btn-dark
+  $('#selectItem').removeClass('btn-light').addClass('btn-dark');
+  selectedLine = instance.currentLine.get();
+  selectedWord = instance.currentWord.get();
+  currentView = instance.currentView.get();
+  console.log("selectedLine is " + selectedLine);
+  if (currentView == 'simple') {
+    image = initCropper("page");
+    const context = image.getContext('2d');
+    const page = instance.currentPage.get();
+    const documentId = instance.currentDocument.get();
+    const lines = Documents.findOne({_id: documentId}).pages[page].lines;
+    //if there are no lines, simulate clicking the exitTool button
+    if (lines.length == 0) {
+      alert("No lines to display. Use the Create Line tool to create a line.");
+      $('#exitTool').click();
+      return;
     }
-    if(currentView == 'line') {
-      //get $('#lineImage') and change it from img-fluid to a calculated width and height
-      calcWidth = $('#lineImage').width();
-      calcHeight = $('#lineImage').height();
-      $('#lineImage').removeClass('img-fluid');
-      //add width and height to the lineImage's style
-      $('#lineImage').css('width', calcWidth + 'px');
-      $('#lineImage').css('height', calcHeight + 'px');
-      image = initCropper("line");
-      const context = image.getContext('2d');
-      const page = instance.currentPage.get();
-      const documentId = instance.currentDocument.get();
-      const words = Documents.findOne({_id: documentId}).pages[page].lines[selectedLine].words;
-      //if there are no words, simulate clicking the exitTool button
-      if (words.length == 0) {
-        alert("No words to display. Use the Create Word tool to create a word.");
-        return;
-      }
-      //sort the words by x1
-      words.sort(function(a, b) {
-        return a.x1 - b.x1;
-      }
-      );
-      //split the canvas into multiple canvases by word
-      words.forEach(function(word) {
-        index = words.indexOf(word);
-        drawButton(image, word.x, 0, word.width, image.height, 'word', index, index);
-      }
-      );
-      //hide the original image with display none
-      setCurrentHelp('To select a word, click on the word.  To cancel, click the close tool button.');
+    //sort the lines by y1
+    lines.sort(function(a, b) {
+      return a.y1 - b.y1;
+    });
+    //split the canvas into multiple canvases by line
+    lines.forEach(function(line) {
+      index = lines.indexOf(line);
+      drawButton(image, 0, line.y1, image.width, line.height, 'line', index, index);
+    });
+    //hide the original image with display none
+    setCurrentHelp('To select a line, click on the line.  To cancel, click the close tool button.');
+  }
+  if(currentView == 'line') {
+    //get $('#lineImage') and change it from img-fluid to a calculated width and height
+    calcWidth = $('#lineImage').width();
+    calcHeight = $('#lineImage').height();
+    $('#lineImage').removeClass('img-fluid');
+    //add width and height to the lineImage's style
+    $('#lineImage').css('width', calcWidth + 'px');
+    $('#lineImage').css('height', calcHeight + 'px');
+    image = initCropper("line");
+    const context = image.getContext('2d');
+    const page = instance.currentPage.get();
+    const documentId = instance.currentDocument.get();
+    const words = Documents.findOne({_id: documentId}).pages[page].lines[selectedLine].words;
+    //if there are no words, simulate clicking the exitTool button
+    if (words.length == 0) {
+      alert("No words to display. Use the Create Word tool to create a word.");
+      $('#exitTool').click();
+      return;
     }
-    if(currentView == 'word') {
-      //get $('#wordImage') and change it from img-fluid to a calculated width and height
-      calcWidth = $('#wordImage').width();
-      calcHeight = $('#wordImage').height();
-      $('#wordImage').removeClass('img-fluid');
-      //add width and height to the wordImage's style
-      $('#wordImage').css('width', calcWidth + 'px');
-      $('#wordImage').css('height', calcHeight + 'px');
-      image = initCropper("word");
-      const context = image.getContext('2d');
-      const page = instance.currentPage.get();
-      const documentId = instance.currentDocument.get();
-      const phonemes = Documents.findOne({_id: documentId}).pages[page].lines[selectedLine].words[selectedWord].phonemes;
-      const glyphs = Documents.findOne({_id: documentId}).pages[page].lines[selectedLine].words[selectedWord].glyph;
-      //if there are no phonemes or words, simulate clicking the exitTool button
-      if (phonemes.length == 0 && glyphs.length == 0) {
-        alert("No phonemes or glyphs to display. Use the Create Phoneme or Create Glyph tool to create a phoneme or glyph.");
-        return;
-      }
-      //sort the phonemes by x1
-      phonemes.sort(function(a, b) {
-        return a.x1 - b.x1;
-      }
-      );
-      //sort the glyphs by x1
-      glyphs.sort(function(a, b) {
-        return a.x1 - b.x1;
-      }
-      );
-      //split the canvas into multiple canvases by phoneme
-      phonemes.forEach(function(phoneme) {
-        index = phonemes.indexOf(phoneme);
-        drawButton(image, phoneme.x, 0, phoneme.width, image.height, 'phoneme', index, index);
-      });
-      //split the canvas into multiple canvases by glyph, these buttons appear over the phoneme buttons
-      glyphs.forEach(function(glyph) {
-        index = glyphs.indexOf(glyph);
-        drawButton(image, glyph.x, 0, glyph.width, image.height, 'glyph', index, index);
-      });
-      //hide the original image with display none
-      setCurrentHelp('To select a phoneme or glyph, click on the phoneme or glyph.  To cancel, click the close tool button.');
+    //sort the words by x1
+    words.sort(function(a, b) {
+      return a.x - b.x;
+    });
+    //split the canvas into multiple canvases by word
+    words.forEach(function(word) {
+      index = words.indexOf(word);
+      drawButton(image, word.x, 0, word.width, image.height, 'word', index, index);
+    });
+    //hide the original image with display none
+    setCurrentHelp('To select a word, click on the word.  To cancel, click the close tool button.');
+  }
+  if(currentView == 'word') {
+    //get $('#wordImage') and change it from img-fluid to a calculated width and height
+    calcWidth = $('#wordImage').width();
+    calcHeight = $('#wordImage').height();
+    $('#wordImage').removeClass('img-fluid');
+    //add width and height to the wordImage's style
+    $('#wordImage').css('width', calcWidth + 'px');
+    $('#wordImage').css('height', calcHeight + 'px');
+    image = initCropper("word");
+    const context = image.getContext('2d');
+    const page = instance.currentPage.get();
+    const documentId = instance.currentDocument.get();
+    const phonemes = Documents.findOne({_id: documentId}).pages[page].lines[selectedLine].words[selectedWord].phonemes;
+    const glyphs = Documents.findOne({_id: documentId}).pages[page].lines[selectedLine].words[selectedWord].glyph;
+    //if there are no phonemes or words, simulate clicking the exitTool button
+    if (phonemes.length == 0 && glyphs.length == 0) {
+      alert("No phonemes or glyphs to display. Use the Create Phoneme or Create Glyph tool to create a phoneme or glyph.");
+      $('#exitTool').click();
+      return;
     }
-  },
+    //sort the phonemes by x1
+    phonemes.sort(function(a, b) {
+      return a.x - b.x;
+    });
+    //sort the glyphs by x1
+    glyphs.sort(function(a, b) {
+      return a.x - b.x;
+    });
+    //split the canvas into multiple canvases by phoneme
+    phonemes.forEach(function(phoneme) {
+      index = phonemes.indexOf(phoneme);
+      drawButton(image, phoneme.x, 0, phoneme.width, image.height, 'phoneme', index, index);
+    });
+    //split the canvas into multiple canvases by glyph, these buttons appear over the phoneme buttons
+    glyphs.forEach(function(glyph) {
+      index = glyphs.indexOf(glyph);
+      drawButton(image, glyph.x, 0, glyph.width, image.height, 'glyph', index, index);
+    });
+    //hide the original image with display none
+    setCurrentHelp('To select a phoneme or glyph, click on the phoneme or glyph.  To cancel, click the close tool button.');
+  }
+},
+
   'click .selectElement'(event, instance) {
     event.preventDefault();
     //simulate clicking the exitTool button

--- a/glyphwitch/package-lock.json
+++ b/glyphwitch/package-lock.json
@@ -19,9 +19,9 @@
       }
     },
     "@emnapi/runtime": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.2.0.tgz",
-      "integrity": "sha512-bV21/9LQmcQeCPEg3BDFtvwL6cwiTMksYNWQQ4KOxCZikEGalWtenoZ0wCiukJINlGCIi2KXx01g4FoH/LxpzQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
+      "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
       "optional": true,
       "requires": {
         "tslib": "^2.4.0"
@@ -614,6 +614,11 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
     },
+    "async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1024,9 +1029,9 @@
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
     },
     "es-object-atoms": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.0.tgz",
-      "integrity": "sha512-Ujz8Al/KfOVR7fkaghAB1WvnLsdYxHDWmfoi2vlA2jZWRg31XhIC1a4B+/I24muD8iSbHxJ1JkrfqmWb65P/Mw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "requires": {
         "es-errors": "^1.3.0"
       }
@@ -1093,11 +1098,11 @@
       "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
     },
     "for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.4.tgz",
+      "integrity": "sha512-kKaIINnFpzW6ffJNDjjyjrk21BkDx38c0xa/klsT8VzLCaMEefv4ZTacrcVR4DmgTeBra++jMDAfS/tS799YDw==",
       "requires": {
-        "is-callable": "^1.1.3"
+        "is-callable": "^1.2.7"
       }
     },
     "forever-agent": {
@@ -1283,9 +1288,9 @@
       }
     },
     "gojs": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/gojs/-/gojs-3.0.17.tgz",
-      "integrity": "sha512-hSN2rHfwiuAVjkqEKTUpON3CnZNzIxFPdDFcaBE0ECTGXwYYrh+aLlvAUJTagozAk24rFz3AUIiI/02XpwxV1A=="
+      "version": "3.0.18",
+      "resolved": "https://registry.npmjs.org/gojs/-/gojs-3.0.18.tgz",
+      "integrity": "sha512-CVizMft75LTqzfHk/pQuyxFVhLoxCPGCrjsz/YPYA1OpFdlOB9FLVWaqJPT7hj/vnFRySpr9YqI6EAx2/vbhBg=="
     },
     "gopd": {
       "version": "1.2.0",
@@ -1425,10 +1430,11 @@
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "is-async-function": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.0.tgz",
-      "integrity": "sha512-GExz9MtyhlZyXYLxzlJRj5WUCE661zhDa1Yna52CN57AJsymh+DvXXjyveSioqSRdxvUrdKdvqB1b5cVKsNpWQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
       "requires": {
+        "async-function": "^1.0.0",
         "call-bound": "^1.0.3",
         "get-proto": "^1.0.1",
         "has-tostringtag": "^1.0.2",
@@ -2906,9 +2912,12 @@
       "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
     },
     "psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "requires": {
+        "punycode": "^2.3.1"
+      }
     },
     "punycode": {
       "version": "2.3.1",
@@ -3345,9 +3354,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "optional": true
     },
     "tunnel-agent": {

--- a/glyphwitch/package.json
+++ b/glyphwitch/package.json
@@ -12,7 +12,7 @@
     "babel-runtime": "^6.26.0",
     "canvas": "^2.11.2",
     "cropperjs": "^1.6.2",
-    "gojs": "^3.0.17",
+    "gojs": "^3.0.18",
     "jimp": "^0.22.12",
     "jquery": "^3.7.1",
     "jsoneditor": "^10.1.2",


### PR DESCRIPTION
Added a check for the number of lines and a call to the exitTool function if there are no lines. The tool automatically exits and resets the toolbox when there are no lines, words, phonemes, or glyphs to select.

Code artifacts:
glyphwitch/client/main.js