### PR TITLE
Created route for '/glyphwitch' that renders login or viewpage template

### DIFF
--- a/glyphwitch/client/lib/router.js
+++ b/glyphwitch/client/lib/router.js
@@ -66,6 +66,18 @@ Router.route('/', {
   }
 });
 
+Router.route('/glyphwitch', {
+  name: 'glyphwitch',
+  template: 'home',
+  onBeforeAction: function() {
+    if (Meteor.userId()) {
+      this.redirect('viewPage');
+    } else {
+      this.redirect('login');
+    }
+  }
+});
+
 //logout route, call the logout method
 Router.route('/logout', {
   name: 'logout',


### PR DESCRIPTION
Duplicated '/' route for '/glyphwitch' - using same action

New behavior:
-http://iis.memphis.edu/glyphwitch directs to viewPage (user logged in) or
-http://iis.memphis.edu/glyphwitch directs to login (user not logged in)

Code artifacts:
glyphwitch/client/lib/router.js