### PR TITLE
Fix for start page file selection

### DIFF
--- a/glyphwitch/client/main.js
+++ b/glyphwitch/client/main.js
@@ -350,6 +350,13 @@ Template.selectDocument.events({
     fn2(0);
   
     
+  },
+  'change #selectDoc'(event, instance) {
+    const newDoc = event.target.value;
+    const setDocumentFn = instance.setDocument.get();
+    setDocumentFn(newDoc);
+    const setPageFn = instance.setPage.get();
+    setPageFn(0);
   }
 });
 


### PR DESCRIPTION
Changed the event from "click" to "change" on the select element. Now the user must only click once to select a file.
Compare below:

Before.mov
https://github.com/user-attachments/assets/99a4ea99-1a42-4b98-9d7c-5ec1230c8ad8

After.mov
https://github.com/user-attachments/assets/9da405d2-98a2-4651-a549-d85c1c1a2371

Code artifacts:
glyphwitch/client/main.js