### PR TITLE
Add element glyph feature

### DIFF
--- a/glyphwitch/.meteor/packages
+++ b/glyphwitch/.meteor/packages
@@ -28,3 +28,4 @@ alanning:roles
 accounts-password
 session
 iron:router
+check

--- a/glyphwitch/client/main.html
+++ b/glyphwitch/client/main.html
@@ -510,6 +510,9 @@
           <button type="button" class="btn btn-light me-2" title="Create Glyph" id="createGlyph" style="display: none;">
             <i class="bi bi-file-earmark-font"></i>
           </button>
+          <button type="button" class="btn btn-light me-2" title="Create Element" id="createElement" style="display: none;">
+            <i class="bi bi-bounding-box"></i>
+          </button>
           <button type="button" class="btn btn-danger me-2" title="Exit Tool" id="exitTool" style="display: none;">
             <i class="bi bi-x"></i>
           </button>

--- a/glyphwitch/client/main.js
+++ b/glyphwitch/client/main.js
@@ -1916,6 +1916,11 @@ Template.viewPage.events({
         }
       );
     });
+  },
+  'click .glyphButton'(event, instance) {
+    const glyphIndex = event.target.getAttribute('data-glyph-index');
+    instance.currentGlyph.set(parseInt(glyphIndex, 10));
+    $('#createGlyphModal').modal('show');
   }
 });
 

--- a/glyphwitch/client/main.js
+++ b/glyphwitch/client/main.js
@@ -490,7 +490,7 @@ function resetToolbox() {
     } 
     if(currentTool == 'select') {
       hideAllToolButtons();
-      $('selectTool').removeClass('btn-light').addClass('btn-dark');
+      $('#selectItem').removeClass('btn-light').addClass('btn-dark');
       $('#exitTool').show();
     }
     if(currentTool == 'createWord') {
@@ -510,6 +510,11 @@ function resetToolbox() {
         $('#viewTool').show();
         $('#viewTool').removeClass('btn-light').addClass('btn-dark');
     } 
+    if(currentTool == 'select') {
+      hideAllToolButtons();
+      $('#selectItem').removeClass('btn-light').addClass('btn-dark');
+      $('#exitTool').show();
+    }
     if(currentTool == 'createPhoneme') {
       hideAllToolButtons();
       $('#createPhoneme').removeClass('btn-light').addClass('btn-dark');

--- a/glyphwitch/client/main.js
+++ b/glyphwitch/client/main.js
@@ -2154,7 +2154,6 @@ Template.viewPage.events({
     console.log("DEBUG: createElement - end of handler");
   },
   
-  // ...existing code...
 });
 
 //upload document onCreated function

--- a/glyphwitch/client/main.js
+++ b/glyphwitch/client/main.js
@@ -1881,6 +1881,41 @@ Template.viewPage.events({
             }
         });
     }
+  },
+  'click #createElement'(event, instance) {
+    event.preventDefault();
+    resetToolbox();
+    $('#createElement').removeClass('btn-light').addClass('btn-dark');
+    instance.currentTool.set('createElement');
+
+    const pageIndex = instance.currentPage.get();
+    const documentId = instance.currentDocument.get();
+    const lineIndex = instance.currentLine.get();
+    const wordIndex = instance.currentWord.get();
+    const phonemeIndex = instance.currentPhoneme.get();
+    const glyphIndex = instance.currentGlyph.get();
+
+    // I'm assuming initCropper is already available
+    const glyphCanvas = initCropper('glyph');
+
+    // “crop” callback
+    glyphCanvas.addEventListener('crop', function (cropEvent) {
+      const box = cropEvent.detail; // { x, y, width, height }
+      const dataURL = glyphCanvas.toDataURL('image/png');
+      Meteor.call('addElementToGlyph',
+        documentId, pageIndex, lineIndex, wordIndex, phonemeIndex, glyphIndex,
+        box.x, box.y, box.width, box.height,
+        dataURL,
+        (error, result) => {
+          if (error) {
+            console.error(error);
+            alert("Error creating element");
+          } else {
+            alert("Element created");
+          }
+        }
+      );
+    });
   }
 });
 

--- a/glyphwitch/client/main.js
+++ b/glyphwitch/client/main.js
@@ -2344,6 +2344,26 @@ function setCurrentHelp(help) {
 function handleElementSelection(type, id, instance) {
   console.log("Processing element selection, type is " + type + " and id is " + id);
   
+  // Clean up all overlay buttons before proceeding
+  // This ensures previous selection elements don't remain on screen
+  $('.selectElement').remove();
+  $('.showReferences').remove();
+  
+  // Also clean up any cropper instances
+  const cropper = instance.cropper.get();
+  if (cropper) {
+    cropper.destroy();
+    instance.cropper.set(false);
+  }
+  
+  // Clean up any canvas elements that might be lingering
+  $('canvas#pageImage, canvas#lineImage, canvas#wordImage, canvas#glyphImage').each(function() {
+    // Only remove canvas duplicates, not the original images
+    if ($(this).siblings('img#' + this.id).length) {
+      $(this).remove();
+    }
+  });
+  
   //simulate clicking the exitTool button
   $('#exitTool').click();
   
@@ -2397,6 +2417,15 @@ function handleElementSelection(type, id, instance) {
   instance.currentView.set(type);
   resetToolbox();
   setImage(type, id);
+  
+  // Final cleanup - ensure no selection buttons remain
+  // This redundant check helps catch any buttons that might have been created 
+  // during the setImage or other operations above
+  setTimeout(() => {
+    $('.selectElement').remove();
+    $('.showReferences').remove();
+    console.log(`Selection cleanup complete for ${type} ${id}`);
+  }, 100);
 }
 
 //function to draw a button at a particular location x,y,width,height on canvas with a data-type and data-index.

--- a/glyphwitch/client/main.js
+++ b/glyphwitch/client/main.js
@@ -520,7 +520,15 @@ function resetToolbox() {
       $('#exitTool').show();
       $('#confirmTool').show();
     }
-  } 
+  } else if(currentView == 'glyph') {
+      if(currentTool == 'view') {
+        hideAllToolButtons();
+        $('.toolbox-container button').removeClass('btn-dark').addClass('btn-light')
+        // Limited functionality for glyph view, just show the view tool
+        $('#viewTool').show();
+        $('#viewTool').removeClass('btn-light').addClass('btn-dark');
+      }
+  }
 }
 
 //fucntion to generate document flow using gojs
@@ -696,6 +704,56 @@ function setImage(type, id) {
       //set the currentLine to the line
 
       Template.instance().currentWord.set(id);
+  }
+  if(type == 'glyph') {
+      wordImg = $('#wordImage');
+      imagesrc = $('#wordImage').attr('src');
+      //get the dom element with the id 'wordImage'
+      const image = new Image();
+      image.src = imagesrc;
+      //get the image width and height
+      imageWidth = image.width;
+      imageHeight = image.height;
+      //get the currentDocument
+      //get the word from the currentDocument
+      wordImage = $('#wordImage');
+      currentLine = Template.instance().currentLine.get();
+      currentWord = Template.instance().currentWord.get();
+      line = doc.pages[currentPage].lines[currentLine];
+      word = line.words[currentWord];
+      // Check if we should use glyphs or glyph property
+      const glyphsArray = word.glyphs || word.glyph || [];
+      glyph = glyphsArray[id];
+      canvas = document.createElement('canvas');
+      //set the canvas width and height to the glyph width and height
+      canvas.width = glyph.width;
+      canvas.height = line.height;
+      //get the context of the canvas
+      context = canvas.getContext('2d');
+      //draw the glyph on the canvas
+      context.drawImage(image, glyph.x, 0, glyph.width, line.height, 0, 0, glyph.width, line.height);
+      //get the dataURL of the canvas
+      dataURL = canvas.toDataURL('image/png');
+      //clone the pageImage
+      clone = pageImage.clone();
+      clone.attr('id', 'glyphImage');
+      //set the clone src to the dataURL
+      clone.attr('src', dataURL);
+      //remove all classes from the clone
+      clone.removeClass();
+      //add img-fluid class to the clone
+      clone.addClass('img-fluid');
+      //remove all styles from the clone
+      clone.removeAttr('style');
+      //append the clone to the parent of the pageImage
+      pageImage.parent().append(clone);
+      //show the clone
+      clone.show();
+      //hide the pageImage
+      pageImage.hide();
+      wordImage.hide();
+      //set the currentGlyph to the glyph
+      Template.instance().currentGlyph.set(id);
   }
 }
 
@@ -1169,6 +1227,7 @@ Template.viewPage.events({
   $('#selectItem').removeClass('btn-light').addClass('btn-dark');
   selectedLine = instance.currentLine.get();
   selectedWord = instance.currentWord.get();
+  selectedGlyph = instance.currentGlyph.get();
   currentView = instance.currentView.get();
   console.log("selectedLine is " + selectedLine);
   if (currentView == 'simple') {
@@ -1283,6 +1342,10 @@ Template.viewPage.events({
     //hide the original image with display none
     setCurrentHelp('To select a phoneme or glyph, click on the phoneme or glyph. To cancel, click the close tool button.');
   }
+  if(currentView == 'glyph') {
+    // Similar to word view but for elements within a glyph if needed
+    $('#exitTool').click(); // No additional elements within a glyph for now
+  }
 },
 
   'click .selectElement'(event, instance) {
@@ -1311,6 +1374,11 @@ Template.viewPage.events({
     if (type == 'word') {
       parentId = instance.currentLine.get();
       parenttab = "view-tab-element-line-" + parentId;
+    }
+    if (type == 'glyph') {
+      parentId = instance.currentWord.get();
+      lineId = instance.currentLine.get();
+      parenttab = "view-tab-element-word-" + parentId;
     }
 
     //set the data-parent of the clone to the parent's expected tab id
@@ -1381,6 +1449,18 @@ Template.viewPage.events({
       //get the currentWord
       currentWord = instance.currentWord.get();
       setImage('word', currentWord);
+    }
+    if(tabId == 'glyph') {
+      instance.currentView.set('glyph');
+      instance.currentTool.set('view');
+      resetToolbox();
+      //get the currentLine
+      currentLine = instance.currentLine.get();
+      //get the currentWord
+      currentWord = instance.currentWord.get();
+      //get the currentGlyph
+      currentGlyph = instance.currentGlyph.get();
+      setImage('glyph', currentGlyph);
     }
     if(tabId == 'simple'){
       instance.currentView.set('simple');

--- a/glyphwitch/client/main.js
+++ b/glyphwitch/client/main.js
@@ -1596,6 +1596,27 @@ Template.viewPage.events({
 
     } else if(currentTool == 'createElement') {
       // Similar approach to the other tools - call the server method to add the element
+      const glyphImage = document.getElementById('glyphImage');
+      const canvas = document.createElement('canvas');
+      canvas.width = instance.selectwidth.get();
+      canvas.height = instance.selectheight.get();
+      const context = canvas.getContext('2d');
+      
+      // Extract the element image from the glyph
+      context.drawImage(
+        glyphImage, 
+        instance.selectx1.get(), 
+        instance.selecty1.get(), 
+        instance.selectwidth.get(), 
+        instance.selectheight.get(), 
+        0, 0, 
+        canvas.width, canvas.height
+      );
+      
+      // Get image data
+      const elementImageData = canvas.toDataURL('image/png');
+      
+      // Call modified server method with image data
       ret = Meteor.callAsync('addElementToGlyph', 
         instance.currentDocument.get(), 
         instance.currentPage.get(), 
@@ -1605,7 +1626,8 @@ Template.viewPage.events({
         instance.selectx1.get(),
         instance.selecty1.get(),
         instance.selectwidth.get(),
-        instance.selectheight.get()
+        instance.selectheight.get(),
+        elementImageData  // Pass image data
       );
       alert("element added");
       // Clean up the cropper

--- a/glyphwitch/client/main.js
+++ b/glyphwitch/client/main.js
@@ -1238,34 +1238,50 @@ Template.viewPage.events({
     const context = image.getContext('2d');
     const page = instance.currentPage.get();
     const documentId = instance.currentDocument.get();
-    const phonemes = Documents.findOne({_id: documentId}).pages[page].lines[selectedLine].words[selectedWord].phonemes;
-    const glyphs = Documents.findOne({_id: documentId}).pages[page].lines[selectedLine].words[selectedWord].glyph;
-    //if there are no phonemes or words, simulate clicking the exitTool button
-    if (phonemes.length == 0 && glyphs.length == 0) {
+    const doc = Documents.findOne({_id: documentId});
+    const lineId = instance.currentLine.get();
+    const wordId = instance.currentWord.get();
+    const word = doc.pages[page].lines[lineId].words[wordId];
+    const phonemes = word.phonemes || [];
+    const glyphs = word.glyphs || word.glyph || []; // Handle both possible property names
+    
+    console.log("Found phonemes:", phonemes.length);
+    console.log("Found glyphs:", glyphs.length);
+    
+    // Check if there are no elements to display
+    if (phonemes.length === 0 && glyphs.length === 0) {
       alert("No phonemes or glyphs to display. Use the Create Phoneme or Create Glyph tool to create a phoneme or glyph.");
       $('#exitTool').click();
       return;
     }
-    //sort the phonemes by x1
-    phonemes.sort(function(a, b) {
-      return a.x - b.x;
-    });
-    //sort the glyphs by x1
-    glyphs.sort(function(a, b) {
-      return a.x - b.x;
-    });
-    //split the canvas into multiple canvases by phoneme
-    phonemes.forEach(function(phoneme) {
-      index = phonemes.indexOf(phoneme);
-      drawButton(image, phoneme.x, 0, phoneme.width, image.height, 'phoneme', index, index);
-    });
-    //split the canvas into multiple canvases by glyph, these buttons appear over the phoneme buttons
-    glyphs.forEach(function(glyph) {
-      index = glyphs.indexOf(glyph);
-      drawButton(image, glyph.x, 0, glyph.width, image.height, 'glyph', index, index);
-    });
+    
+    //sort the phonemes by x
+    if (phonemes.length > 0) {
+      phonemes.sort(function(a, b) {
+        return a.x - b.x;
+      });
+      //split the canvas into multiple canvases by phoneme
+      phonemes.forEach(function(phoneme) {
+        index = phonemes.indexOf(phoneme);
+        drawButton(image, phoneme.x, 0, phoneme.width, image.height, 'phoneme', index, index);
+      });
+    }
+    
+    //sort the glyphs by x
+    if (glyphs.length > 0) {
+      glyphs.sort(function(a, b) {
+        return a.x - b.x;
+      });
+      //split the canvas into multiple canvases by glyph
+      glyphs.forEach(function(glyph) {
+        index = glyphs.indexOf(glyph);
+        console.log("Drawing glyph button at:", glyph.x, 0, glyph.width, image.height);
+        drawButton(image, glyph.x, 0, glyph.width, image.height, 'glyph', index, index);
+      });
+    }
+    
     //hide the original image with display none
-    setCurrentHelp('To select a phoneme or glyph, click on the phoneme or glyph.  To cancel, click the close tool button.');
+    setCurrentHelp('To select a phoneme or glyph, click on the phoneme or glyph. To cancel, click the close tool button.');
   }
 },
 

--- a/glyphwitch/client/main.js
+++ b/glyphwitch/client/main.js
@@ -1385,10 +1385,7 @@ Template.viewPage.events({
 
   'click .selectElement'(event, instance) {
     event.preventDefault();
-    //simulate clicking the exitTool button
-    $('#exitTool').click();
-    //get the data-type and data-id from the button
-    const target = event.currentTarget; // Use currentTarget instead of target to get the button, not its children
+    const target = event.currentTarget;
     const type = target.getAttribute('data-type');
     const id = target.getAttribute('data-id');
     
@@ -1404,58 +1401,31 @@ Template.viewPage.events({
     }
     
     console.log("selectElement, type is " + type + " and id is " + id);
-    //copy view-tab-template to it's parent
-    viewTemplate = $('#view-tab-template');
-    clone = viewTemplate.clone(); 
-    //append the clone to the parent
-    viewTemplate.parent().append(clone);
-    //set the id of the clone to view-tab-element-<type>-<id>
-    clone.attr('id', 'view-tab-element-' + type + '-' + id);
-    //set the data-type and data-id of the clone to the type and id
-    clone.attr('data-type', type);
-    clone.attr('data-id', id);
-    //get the parent element type using cases
-    if (type == 'line') {
-      parent = 'simple';
-      parenttab = 'simple';
-    }
-    if (type == 'word') {
-      parentId = instance.currentLine.get();
-      parenttab = "view-tab-element-line-" + parentId;
-    }
-    if (type == 'glyph') {
-      parentId = instance.currentWord.get();
-      lineId = instance.currentLine.get();
-      parenttab = "view-tab-element-word-" + parentId;
-    }
-
-    //set the data-parent of the clone to the parent's expected tab id
-    clone.attr('data-parent', parenttab);
-    clone.attr('id', 'view-tab-element-' + type + '-' + id);
-
-
-    //get the ammount of tabs open
-    tabs = $('#view-tab-template').parent().children().length;
-    //set the clone's data tab index to the number of tabs open
-    clone.attr('data-tab-index', tabs);
-    $(clone).children().attr('data-tab-id', type);
-    //show the clone
-    clone.show();
-    //make all parent's siblings buttons inactive
-    $('#view-tab-template').parent().children().children().removeClass('active');
-    //change all button's aria-selected to false
-    $('#view-tab-template').parent().children().children().attr('aria-selected', 'false');
-    //change the clone's button aria-selected to true
-    clone.children().attr('aria-selected', 'true');
-    clone.children().addClass('active');
-    //prepent <type> uppercase and id to the clone's button text
-    clone.children().prepend(type.charAt(0).toUpperCase() + type.slice(1) + ' ' + id + ' ');
-    //set the current view to the type
-    instance.currentView.set(type);
-    resetToolbox();
-    setImage(type, id);
-  
+    
+    // Call the shared function
+    handleElementSelection(type, id, instance);
   },
+  
+  'click .showReferences'(event, instance) {
+    event.preventDefault();
+    const target = event.currentTarget;
+    debugGlyphButton(target, 'showReferences click');
+    
+    // Check if this is a glyph button
+    const type = target.getAttribute('data-type');
+    if (type === 'glyph') {
+      console.log('Glyph button clicked (showReferences class):', 
+        'ID:', target.getAttribute('data-id'),
+        'Element:', target);
+      
+      // Get the id
+      const id = target.getAttribute('data-id');
+      
+      // Call the same element selection logic used by selectElement
+      handleElementSelection(type, id, instance);
+    }
+  },
+  
   'click .open-tab'(event, instance) {
     event.preventDefault();
     //get the clicked tab data-tab-id
@@ -2078,16 +2048,11 @@ Template.viewPage.events({
         'ID:', target.getAttribute('data-id'),
         'Element:', target);
       
-      // Process the glyph selection similar to selectElement
-      // This ensures glyph clicks are handled regardless of the class
+      // Get the id
       const id = target.getAttribute('data-id');
       
-      // The rest would be the same as in selectElement handler
-      // For now just highlight this was detected
-      alert(`Glyph ${id} clicked (showReferences handler)`);
-      
-      // Optionally, trigger the selectElement behavior
-      // You could dispatch a custom event or refactor the code to call a shared function
+      // Call the same element selection logic used by selectElement
+      handleElementSelection(type, id, instance);
     }
   }
 });
@@ -2243,4 +2208,63 @@ function isContainedBy(point, x1, y1, x2, y2) {
 function setCurrentHelp(help) {
   const instance = Template.instance();
   instance.currentHelp.set(help);
+}
+
+// Create a shared function that both handlers can use
+function handleElementSelection(type, id, instance) {
+  console.log("Processing element selection, type is " + type + " and id is " + id);
+  
+  //simulate clicking the exitTool button
+  $('#exitTool').click();
+  
+  //copy view-tab-template to it's parent
+  viewTemplate = $('#view-tab-template');
+  clone = viewTemplate.clone(); 
+  //append the clone to the parent
+  viewTemplate.parent().append(clone);
+  //set the id of the clone to view-tab-element-<type>-<id>
+  clone.attr('id', 'view-tab-element-' + type + '-' + id);
+  //set the data-type and data-id of the clone to the type and id
+  clone.attr('data-type', type);
+  clone.attr('data-id', id);
+  //get the parent element type using cases
+  let parent, parenttab;
+  if (type == 'line') {
+    parent = 'simple';
+    parenttab = 'simple';
+  }
+  if (type == 'word') {
+    parentId = instance.currentLine.get();
+    parenttab = "view-tab-element-line-" + parentId;
+  }
+  if (type == 'glyph') {
+    parentId = instance.currentWord.get();
+    lineId = instance.currentLine.get();
+    parenttab = "view-tab-element-word-" + parentId;
+  }
+
+  //set the data-parent of the clone to the parent's expected tab id
+  clone.attr('data-parent', parenttab);
+  clone.attr('id', 'view-tab-element-' + type + '-' + id);
+
+  //get the amount of tabs open
+  tabs = $('#view-tab-template').parent().children().length;
+  //set the clone's data tab index to the number of tabs open
+  clone.attr('data-tab-index', tabs);
+  $(clone).children().attr('data-tab-id', type);
+  //show the clone
+  clone.show();
+  //make all parent's siblings buttons inactive
+  $('#view-tab-template').parent().children().children().removeClass('active');
+  //change all button's aria-selected to false
+  $('#view-tab-template').parent().children().children().attr('aria-selected', 'false');
+  //change the clone's button aria-selected to true
+  clone.children().attr('aria-selected', 'true');
+  clone.children().addClass('active');
+  //prepend <type> uppercase and id to the clone's button text
+  clone.children().prepend(type.charAt(0).toUpperCase() + type.slice(1) + ' ' + id + ' ');
+  //set the current view to the type
+  instance.currentView.set(type);
+  resetToolbox();
+  setImage(type, id);
 }

--- a/glyphwitch/client/main.js
+++ b/glyphwitch/client/main.js
@@ -918,6 +918,9 @@ function drawButton(image, x, y, width, height, type, text, id) {
     label.style.backgroundColor = 'yellow';
     label.style.color = 'black';
     defaultClass = 'showReferences';
+    
+    // Debug each glyph button as it's created
+    console.log(`Creating glyph button: ID=${id}, X=${x}, Width=${width}, Class=${defaultClass}`);
   }
 
 
@@ -930,7 +933,13 @@ function drawButton(image, x, y, width, height, type, text, id) {
   //append the button to the parent
   parent.appendChild(button);
   
-  
+  // Add a click event listener directly to the button for debugging
+  if (type === 'glyph') {
+    button.addEventListener('click', function(e) {
+      console.log(`Direct glyph button click detected: ID=${id}`);
+      debugGlyphButton(this, 'direct click listener');
+    });
+  }
   
 }
 
@@ -976,10 +985,25 @@ function replaceWithOriginalImage() {
   $('#pageImage').parent().children('canvas').remove();
 }
 
-
-
-
-
+function debugGlyphButton(element, eventType) {
+  const type = element.getAttribute('data-type');
+  const id = element.getAttribute('data-id');
+  if (type === 'glyph') {
+    console.group('Glyph Button Debug - ' + eventType);
+    console.log('Event type:', eventType);
+    console.log('Button type:', type);
+    console.log('Button ID:', id);
+    console.log('Element:', element);
+    console.log('CSS classes:', element.className);
+    console.log('Position:', {
+      left: element.style.left,
+      top: element.style.top,
+      width: element.style.width,
+      height: element.style.height
+    });
+    console.groupEnd();
+  }
+}
 
 Template.viewPage.helpers({
   currentDocument() {
@@ -1331,12 +1355,23 @@ Template.viewPage.events({
       glyphs.sort(function(a, b) {
         return a.x - b.x;
       });
+      console.log(`Found ${glyphs.length} glyphs to display in word view`);
+      
       //split the canvas into multiple canvases by glyph
       glyphs.forEach(function(glyph) {
         index = glyphs.indexOf(glyph);
         console.log("Drawing glyph button at:", glyph.x, 0, glyph.width, image.height);
         drawButton(image, glyph.x, 0, glyph.width, image.height, 'glyph', index, index);
       });
+      
+      // After creating all the glyph buttons, add a debug message
+      setTimeout(() => {
+        const glyphButtons = document.querySelectorAll('button[data-type="glyph"]');
+        console.log(`Glyph buttons created: ${glyphButtons.length}`);
+        glyphButtons.forEach(btn => {
+          console.log(`Glyph button: ID=${btn.getAttribute('data-id')}, Classes=${btn.className}`);
+        });
+      }, 100);
     }
     
     //hide the original image with display none
@@ -1353,8 +1388,21 @@ Template.viewPage.events({
     //simulate clicking the exitTool button
     $('#exitTool').click();
     //get the data-type and data-id from the button
-    const type = event.target.getAttribute('data-type');
-    const id = event.target.getAttribute('data-id');
+    const target = event.currentTarget; // Use currentTarget instead of target to get the button, not its children
+    const type = target.getAttribute('data-type');
+    const id = target.getAttribute('data-id');
+    
+    // Debug logging specifically for glyphs
+    if (type === 'glyph') {
+      console.group('Glyph Selection Debug');
+      console.log('Glyph button clicked (selectElement handler):', 
+        'ID:', id,
+        'Element:', target);
+      console.log('Event target:', event.target);
+      console.log('Event currentTarget:', event.currentTarget);
+      console.groupEnd();
+    }
+    
     console.log("selectElement, type is " + type + " and id is " + id);
     //copy view-tab-template to it's parent
     viewTemplate = $('#view-tab-template');
@@ -2017,6 +2065,30 @@ Template.viewPage.events({
     const glyphIndex = event.target.getAttribute('data-glyph-index');
     instance.currentGlyph.set(parseInt(glyphIndex, 10));
     $('#createGlyphModal').modal('show');
+  },
+  'click .showReferences'(event, instance) {
+    event.preventDefault();
+    const target = event.currentTarget;
+    debugGlyphButton(target, 'showReferences click');
+    
+    // Check if this is a glyph button
+    const type = target.getAttribute('data-type');
+    if (type === 'glyph') {
+      console.log('Glyph button clicked (showReferences class):', 
+        'ID:', target.getAttribute('data-id'),
+        'Element:', target);
+      
+      // Process the glyph selection similar to selectElement
+      // This ensures glyph clicks are handled regardless of the class
+      const id = target.getAttribute('data-id');
+      
+      // The rest would be the same as in selectElement handler
+      // For now just highlight this was detected
+      alert(`Glyph ${id} clicked (showReferences handler)`);
+      
+      // Optionally, trigger the selectElement behavior
+      // You could dispatch a custom event or refactor the code to call a shared function
+    }
   }
 });
 

--- a/glyphwitch/server/collections.js
+++ b/glyphwitch/server/collections.js
@@ -827,8 +827,16 @@ Meteor.methods({
           throw new Meteor.Error('invalid-parameters', 'All numeric parameters must be valid numbers');
         }
         
-        // Create the element object with parsed numeric values
+        // Create the element object with parsed numeric values and explicit element ID
+        const elementId = Elements.insert({
+          createdAt: new Date(),
+          boundingBox: { x: numX, y: numY, width: numWidth, height: numHeight },
+          glyphId: document + "-" + numPage + "-" + numLine + "-" + numWord + "-" + numGlyph,
+          addedBy: this.userId || 'anonymous'
+        });
+        
         const element = {
+          elementId,  // Adding explicit element ID here
           x: numX,
           y: numY,
           width: numWidth,
@@ -889,7 +897,7 @@ Meteor.methods({
         console.log(`Element successfully added to glyph at position [${numPage}, ${numLine}, ${numWord}, ${numGlyph}]`);
         return {
           success: true,
-          elementId: glyphsArr[numGlyph].elements.length - 1
+          elementId: elementId // Return the actual element ID instead of array index
         };
       },
 });

--- a/glyphwitch/server/collections.js
+++ b/glyphwitch/server/collections.js
@@ -789,7 +789,109 @@ Meteor.methods({
         doc.pages[pageIndex].lines[lineIndex].words[wordIndex].phonemes[phonemeIndex].glyphs[glyphIndex] = glyph;
         Documents.update(documentId, { $set: { pages: doc.pages } });
         return elementId;
-      }
+      },
+      addElementToGlyph: function(document, page, line, word, glyph, x, y, width, height) {
+        // Log received parameters for debugging
+        console.log("addElementToGlyph in collections.js called with:", {
+          document, page, line, word, glyph, x, y, width, height
+        });
+        
+        // Check document is a string
+        check(document, String);
+        
+        // Check and convert indices - accept both strings and numbers
+        check(page, Match.OneOf(String, Number));
+        check(line, Match.OneOf(String, Number));
+        check(word, Match.OneOf(String, Number));
+        check(glyph, Match.OneOf(String, Number));
+        
+        // Check and convert coordinate values - accept both strings and numbers
+        check(x, Match.OneOf(String, Number));
+        check(y, Match.OneOf(String, Number));
+        check(width, Match.OneOf(String, Number));
+        check(height, Match.OneOf(String, Number));
+    
+        // Convert all numeric parameters to actual numbers
+        const numPage = parseInt(page);
+        const numLine = parseInt(line);
+        const numWord = parseInt(word);
+        const numGlyph = parseInt(glyph);
+        const numX = parseFloat(x);
+        const numY = parseFloat(y);
+        const numWidth = parseFloat(width);
+        const numHeight = parseFloat(height);
+        
+        // Validate all parsed values are actual numbers
+        if (isNaN(numPage) || isNaN(numLine) || isNaN(numWord) || isNaN(numGlyph) ||
+            isNaN(numX) || isNaN(numY) || isNaN(numWidth) || isNaN(numHeight)) {
+          throw new Meteor.Error('invalid-parameters', 'All numeric parameters must be valid numbers');
+        }
+        
+        // Create the element object with parsed numeric values
+        const element = {
+          x: numX,
+          y: numY,
+          width: numWidth,
+          height: numHeight,
+          addedAt: new Date(),
+          addedBy: this.userId || 'anonymous'
+        };
+        
+        // Get the document
+        const doc = Documents.findOne({ _id: document });
+        if (!doc) {
+          throw new Meteor.Error('document-not-found', 'Document not found');
+        }
+        
+        // Get the page
+        if (!doc.pages || !doc.pages[numPage]) {
+          throw new Meteor.Error('page-not-found', 'Page not found');
+        }
+        
+        // Get the line
+        if (!doc.pages[numPage].lines || !doc.pages[numPage].lines[numLine]) {
+          throw new Meteor.Error('line-not-found', 'Line not found');
+        }
+        
+        // Get the word
+        if (!doc.pages[numPage].lines[numLine].words || !doc.pages[numPage].lines[numLine].words[numWord]) {
+          throw new Meteor.Error('word-not-found', 'Word not found');
+        }
+        
+        // Check if the word has glyphs property (could be glyphs or glyph)
+        const wordObj = doc.pages[numPage].lines[numLine].words[numWord];
+        let glyphsArr = wordObj.glyphs || wordObj.glyph || [];
+        
+        // Check if the glyph exists
+        if (!glyphsArr[numGlyph]) {
+          throw new Meteor.Error('glyph-not-found', 'Glyph not found');
+        }
+        
+        // Create elements array if it doesn't exist
+        if (!glyphsArr[numGlyph].elements) {
+          glyphsArr[numGlyph].elements = [];
+        }
+        
+        // Add the element
+        glyphsArr[numGlyph].elements.push(element);
+        
+        // Update the document
+        // First, determine which property to update (glyphs or glyph)
+        if (wordObj.glyphs) {
+          doc.pages[numPage].lines[numLine].words[numWord].glyphs[numGlyph].elements = glyphsArr[numGlyph].elements;
+        } else if (wordObj.glyph) {
+          doc.pages[numPage].lines[numLine].words[numWord].glyph[numGlyph].elements = glyphsArr[numGlyph].elements;
+        }
+        
+        // Update the document in the database
+        Documents.update({ _id: document }, { $set: { pages: doc.pages } });
+        
+        console.log(`Element successfully added to glyph at position [${numPage}, ${numLine}, ${numWord}, ${numGlyph}]`);
+        return {
+          success: true,
+          elementId: glyphsArr[numGlyph].elements.length - 1
+        };
+      },
 });
 
 //Define Publications for the collections. They must be exported to be used in the main server file. 

--- a/glyphwitch/server/methods.js
+++ b/glyphwitch/server/methods.js
@@ -1,88 +1,124 @@
-// ...existing code...
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+import { Match } from 'meteor/check';
 
-/**
- * Add an element to a glyph
- * @param {String} documentId - The document ID
- * @param {Number} pageIndex - The page index
- * @param {Number} lineIndex - The line index
- * @param {Number} wordIndex - The word index
- * @param {Number} glyphIndex - The glyph index
- * @param {Number} x - The x position of the element
- * @param {Number} y - The y position of the element
- * @param {Number} width - The width of the element
- * @param {Number} height - The height of the element
- * @returns {Object} - The result of the operation
- */
-'addElementToGlyph': function(documentId, pageIndex, lineIndex, wordIndex, glyphIndex, x, y, width, height) {
-  // Validation
-  check(documentId, String);
-  check(pageIndex, Number);
-  check(lineIndex, Number);
-  check(wordIndex, Number);
-  check(glyphIndex, Number);
-  check(x, Number);
-  check(y, Number);
-  check(width, Number);
-  check(height, Number);
-  
-  // Only allow logged-in users
-  if (!this.userId) {
-    throw new Meteor.Error('not-authorized', 'You must be logged in to add an element to a glyph');
-  }
-  
-  // Get the document
-  const document = Documents.findOne({_id: documentId});
-  if (!document) {
-    throw new Meteor.Error('document-not-found', 'Document not found');
-  }
-  
-  // Create the element object
-  const element = {
-    x: x,
-    y: y,
-    width: width,
-    height: height,
-    addedBy: this.userId,
-    addedOn: new Date()
-  };
-  
-  // Check if the glyph exists and has an elements array
-  const page = document.pages[pageIndex];
-  const line = page.lines[lineIndex];
-  const word = line.words[wordIndex];
-  
-  // Handle both possible property names (glyphs or glyph)
-  const glyphsArray = word.glyphs || word.glyph || [];
-  
-  // Check if the glyph exists
-  if (glyphIndex >= glyphsArray.length) {
-    throw new Meteor.Error('glyph-not-found', 'Glyph not found');
-  }
-  
-  // Get the glyph
-  const glyph = glyphsArray[glyphIndex];
-  
-  // Initialize elements array if it doesn't exist
-  if (!glyph.elements) {
-    glyph.elements = [];
-  }
-  
-  // Add the element to the glyph
-  glyph.elements.push(element);
-  
-  // Update the document
-  // Handle both possible property names
-  if (word.glyphs) {
-    word.glyphs[glyphIndex] = glyph;
-  } else if (word.glyph) {
-    word.glyph[glyphIndex] = glyph;
-  }
-  
-  // Update the document in the database
-  Documents.update({_id: documentId}, {$set: {pages: document.pages}});
-  
-  return {
-    success: true,
-    message: 'Element added to glyph'
-  };
-}
+Meteor.methods({
+
+  /**
+   * Add a new element to a glyph
+   * @param {String} document - Document ID
+   * @param {Number|String} page - Page index
+   * @param {Number|String} line - Line index
+   * @param {Number|String} word - Word index
+   * @param {Number|String} glyph - Glyph index
+   * @param {Number|String} x - X coordinate
+   * @param {Number|String} y - Y coordinate
+   * @param {Number|String} width - Width
+   * @param {Number|String} height - Height
+   * @returns {Object} - Result object
+   */
+  addElementToGlyph(document, page, line, word, glyph, x, y, width, height) {
+    // Log received parameters to debug
+    console.log("addElementToGlyph received params:", {
+      document, page, line, word, glyph, x, y, width, height
+    });
+    
+    // Check document is a string
+    check(document, String);
+    
+    // Check and convert indices - accept both strings and numbers
+    check(page, Match.OneOf(String, Number));
+    check(line, Match.OneOf(String, Number));
+    check(word, Match.OneOf(String, Number));
+    check(glyph, Match.OneOf(String, Number));
+    
+    // Check and convert coordinate values - accept both strings and numbers
+    check(x, Match.OneOf(String, Number));
+    check(y, Match.OneOf(String, Number));
+    check(width, Match.OneOf(String, Number));
+    check(height, Match.OneOf(String, Number));
+
+    // Convert all numeric parameters to actual numbers
+    const numPage = parseInt(page);
+    const numLine = parseInt(line);
+    const numWord = parseInt(word);
+    const numGlyph = parseInt(glyph);
+    const numX = parseFloat(x);
+    const numY = parseFloat(y);
+    const numWidth = parseFloat(width);
+    const numHeight = parseFloat(height);
+    
+    // Validate all parsed values are actual numbers
+    if (isNaN(numPage) || isNaN(numLine) || isNaN(numWord) || isNaN(numGlyph) ||
+        isNaN(numX) || isNaN(numY) || isNaN(numWidth) || isNaN(numHeight)) {
+      throw new Meteor.Error('invalid-parameters', 'All numeric parameters must be valid numbers');
+    }
+    
+    // Create the element object with parsed numeric values
+    const element = {
+      x: numX,
+      y: numY,
+      width: numWidth,
+      height: numHeight,
+      addedAt: new Date(),
+      addedBy: this.userId || 'anonymous'
+    };
+
+    console.log(`Adding element to glyph: doc=${document}, page=${numPage}, line=${numLine}, word=${numWord}, glyph=${numGlyph}`);
+    console.log('Element:', element);
+
+    // Get the document
+    const doc = Documents.findOne({ _id: document });
+    if (!doc) {
+      throw new Meteor.Error('not-found', 'Document not found');
+    }
+
+    // Get the page
+    if (!doc.pages || !doc.pages[numPage]) {
+      throw new Meteor.Error('not-found', 'Page not found');
+    }
+
+    // Get the line
+    if (!doc.pages[numPage].lines || !doc.pages[numPage].lines[numLine]) {
+      throw new Meteor.Error('not-found', 'Line not found');
+    }
+
+    // Get the word
+    if (!doc.pages[numPage].lines[numLine].words || !doc.pages[numPage].lines[numLine].words[numWord]) {
+      throw new Meteor.Error('not-found', 'Word not found');
+    }
+
+    // Check if the word has glyphs property (could be glyphs or glyph)
+    const wordObj = doc.pages[numPage].lines[numLine].words[numWord];
+    let glyphsArr = wordObj.glyphs || wordObj.glyph || [];
+
+    // Check if the glyph exists
+    if (!glyphsArr[numGlyph]) {
+      throw new Meteor.Error('not-found', 'Glyph not found');
+    }
+
+    // Create elements array if it doesn't exist
+    if (!glyphsArr[numGlyph].elements) {
+      glyphsArr[numGlyph].elements = [];
+    }
+
+    // Add the element
+    glyphsArr[numGlyph].elements.push(element);
+
+    // Update the document
+    // First, determine which property to update (glyphs or glyph)
+    const updatePath = wordObj.glyphs ? 
+      `pages.${numPage}.lines.${numLine}.words.${numWord}.glyphs.${numGlyph}.elements` : 
+      `pages.${numPage}.lines.${numLine}.words.${numWord}.glyph.${numGlyph}.elements`;
+
+    const updateObj = {};
+    updateObj[updatePath] = glyphsArr[numGlyph].elements;
+
+    Documents.update({ _id: document }, { $set: updateObj });
+
+    return {
+      success: true,
+      elementId: glyphsArr[numGlyph].elements.length - 1
+    };
+  },
+});

--- a/glyphwitch/server/methods.js
+++ b/glyphwitch/server/methods.js
@@ -1,0 +1,90 @@
+// ...existing code...
+
+/**
+ * Add an element to a glyph
+ * @param {String} documentId - The document ID
+ * @param {Number} pageIndex - The page index
+ * @param {Number} lineIndex - The line index
+ * @param {Number} wordIndex - The word index
+ * @param {Number} glyphIndex - The glyph index
+ * @param {Number} x - The x position of the element
+ * @param {Number} y - The y position of the element
+ * @param {Number} width - The width of the element
+ * @param {Number} height - The height of the element
+ * @returns {Object} - The result of the operation
+ */
+'addElementToGlyph': function(documentId, pageIndex, lineIndex, wordIndex, glyphIndex, x, y, width, height) {
+  // Validation
+  check(documentId, String);
+  check(pageIndex, Number);
+  check(lineIndex, Number);
+  check(wordIndex, Number);
+  check(glyphIndex, Number);
+  check(x, Number);
+  check(y, Number);
+  check(width, Number);
+  check(height, Number);
+  
+  // Only allow logged-in users
+  if (!this.userId) {
+    throw new Meteor.Error('not-authorized', 'You must be logged in to add an element to a glyph');
+  }
+  
+  // Get the document
+  const document = Documents.findOne({_id: documentId});
+  if (!document) {
+    throw new Meteor.Error('document-not-found', 'Document not found');
+  }
+  
+  // Create the element object
+  const element = {
+    x: x,
+    y: y,
+    width: width,
+    height: height,
+    addedBy: this.userId,
+    addedOn: new Date()
+  };
+  
+  // Check if the glyph exists and has an elements array
+  const page = document.pages[pageIndex];
+  const line = page.lines[lineIndex];
+  const word = line.words[wordIndex];
+  
+  // Handle both possible property names (glyphs or glyph)
+  const glyphsArray = word.glyphs || word.glyph || [];
+  
+  // Check if the glyph exists
+  if (glyphIndex >= glyphsArray.length) {
+    throw new Meteor.Error('glyph-not-found', 'Glyph not found');
+  }
+  
+  // Get the glyph
+  const glyph = glyphsArray[glyphIndex];
+  
+  // Initialize elements array if it doesn't exist
+  if (!glyph.elements) {
+    glyph.elements = [];
+  }
+  
+  // Add the element to the glyph
+  glyph.elements.push(element);
+  
+  // Update the document
+  // Handle both possible property names
+  if (word.glyphs) {
+    word.glyphs[glyphIndex] = glyph;
+  } else if (word.glyph) {
+    word.glyph[glyphIndex] = glyph;
+  }
+  
+  // Update the document in the database
+  Documents.update({_id: documentId}, {$set: {pages: document.pages}});
+  
+  return {
+    success: true,
+    message: 'Element added to glyph'
+  };
+}
+
+// ...existing code...

--- a/glyphwitch/server/methods.js
+++ b/glyphwitch/server/methods.js
@@ -86,5 +86,3 @@
     message: 'Element added to glyph'
   };
 }
-
-// ...existing code...


### PR DESCRIPTION
https://github.com/user-attachments/assets/447ae974-fb32-40e6-a629-276f65430f20

- Implemented Elements collection that contains both the element's coordinates and image data
- Added createElement tool that stores the coordinates of the element inside of the Glyph and the Element ID
- Glyphs are now viewable using selectItem tool
- Elements are now fully creatable and viewable
- Glyph and elements tabs work

Code Artifacts:
glyphwitch/.meteor/packages
glyphwitch/client/main.html
glyphwitch/client/main.js
glyphwitch/server/collections.js
glyphwitch/server/methods.js